### PR TITLE
Change address of weblab site to new one in Skeleton.js

### DIFF
--- a/client/src/components/pages/Skeleton.js
+++ b/client/src/components/pages/Skeleton.js
@@ -27,7 +27,7 @@ const Skeleton = ({ userId, handleLogin, handleLogout }) => {
       <ul>
         <li>
           Change the Frontend CLIENT_ID (Skeleton.js) to your team's CLIENT_ID (obtain this at
-          http://weblab.us/clientid)
+          http://weblab.is/clientid)
         </li>
         <li>Change the Server CLIENT_ID to the same CLIENT_ID (auth.js)</li>
         <li>


### PR DESCRIPTION
I noticed that the address in the Skeleton intro page is pointing to weblab.us instead of weblab.is ...